### PR TITLE
Ensure that the Linux target builds for x86

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 	@rm -rf target/
 
 build: clean
-	@env GOOS=linux go build $(GOFLAGS) -o target/protoc-gen-graphql.linux
+	@env GOOS=linux GOARCH=amd64 go build $(GOFLAGS) -o target/protoc-gen-graphql.linux
 	@env GOOS=darwin go build $(GOFLAGS) -o target/protoc-gen-graphql.darwin
 
 fixtures/money.pb: fixtures/money.proto


### PR DESCRIPTION
Fixes an arch issue where the Go compiler will implicitly target ARM on an M1 mac.

## Before
```shell
file target/protoc-gen-graphql.linux
target/protoc-gen-graphql.linux: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=fA59KlNsFs3hpDN5kST9/-UjG2GP2I7Bbv0QV9N7H/p3f9UqA20U9MXxGhoPNJ/_16Uhb6VX58bSuQIAcBZ, with debug_info, not stripped
```

## After
```shell
file target/protoc-gen-graphql.linux
target/protoc-gen-graphql.linux: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, Go BuildID=YUAGTBmMv2nJgWpTFzLF/o_LB1aaHOfTfebeyIh92/6_1uyJMZWBqnGGe2hRsd/mPxCUcGaDsoVBw-oF8Ax, with debug_info, not stripped
```